### PR TITLE
Add constant bitrate to MP4 output

### DIFF
--- a/loom.py
+++ b/loom.py
@@ -3979,6 +3979,10 @@ class LOOM_OT_render_image_sequence(bpy.types.Operator):
                 "-video_size", f"{width}x{height}",
                 "-i", pattern,
                 "-c:v", "libx264",
+                "-b:v", "60M",
+                "-minrate", "60M",
+                "-maxrate", "60M",
+                "-bufsize", "60M",
                 "-pix_fmt", "yuv420p",
                 mp4_path
             ], check=True)


### PR DESCRIPTION
## Summary
- tweak `combine_to_mp4` to encode the preview video using constant 60 Mbps

## Testing
- `python -m py_compile loom.py`
